### PR TITLE
Update provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.27"
     }
-    archive = "~> 1.3"
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.3.0"
+    }
   }
 }


### PR DESCRIPTION
Fix incompatible provider version error
```
│ Provider registry.terraform.io/hashicorp/archive v1.3.0 does not have a package available for your current platform, darwin_arm64.
```