### PR TITLE
Additional permission for GHA -> Lambda with code signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -118,4 +117,3 @@
 | <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
 | <a name="output_lambda_role_unique_id"></a> [lambda\_role\_unique\_id](#output\_lambda\_role\_unique\_id) | The unique id of the IAM role created for the Lambda Function |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | The qualified arn of the lambda function to be associated with Cloudfront as a Lambda@Edge function |
-<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.3.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
 
 ## Modules
 
@@ -91,8 +91,8 @@
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function. | `string` | `null` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Function runtime | `string` | `"nodejs18.x"` | no |
-| <a name="input_signer_profile_name"></a> [signer\_profile\_name](#input\_signer\_profile\_name) | Name of the signer profile to use for signing job | `string` | `null` | no |
 | <a name="input_signing_bucket_name"></a> [signing\_bucket\_name](#input\_signing\_bucket\_name) | Name of the S3 bucket to store code for signing job | `string` | `null` | no |
+| <a name="input_signing_profile_name"></a> [signing\_profile\_name](#input\_signing\_profile\_name) | Name of the signer signing profile to use for signing job | `string` | `null` | no |
 | <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | (Optional) Snap start settings for low-latency startups | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `string` | `null` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-## Requirements
-
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
@@ -10,8 +8,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.3.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.27 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -25,11 +26,13 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_role_policy.sign_code](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.update_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.update_lambda_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [archive_file.dummy](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.sign_code](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.update_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.update_lambda_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -52,9 +55,10 @@
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | Amazon Resource Name (ARN) for a Code Signing Configuration | `string` | `null` | no |
 | <a name="input_cors"></a> [cors](#input\_cors) | CORS settings to be used by the Lambda Function URL | `any` | `{}` | no |
 | <a name="input_create_current_version_allowed_triggers"></a> [create\_current\_version\_allowed\_triggers](#input\_create\_current\_version\_allowed\_triggers) | Whether to allow triggers on current version of Lambda Function (this will revoke permissions from previous version because Terraform manages only current resources) | `bool` | `true` | no |
-| <a name="input_create_github_actions_edge_role"></a> [create\_github\_actions\_edge\_role](#input\_create\_github\_actions\_edge\_role) | controls whether to create for lambda edge functions | `bool` | `false` | no |
+| <a name="input_create_github_actions_edge_role"></a> [create\_github\_actions\_edge\_role](#input\_create\_github\_actions\_edge\_role) | Controls whether to create for lambda edge functions | `bool` | `false` | no |
 | <a name="input_create_github_actions_oidc_provider"></a> [create\_github\_actions\_oidc\_provider](#input\_create\_github\_actions\_oidc\_provider) | Controls Whether to create openid connect provider. | `bool` | `false` | no |
 | <a name="input_create_github_actions_role"></a> [create\_github\_actions\_role](#input\_create\_github\_actions\_role) | Controls whether to create AWS OIDC integration GitHub Actions | `bool` | `true` | no |
+| <a name="input_create_github_actions_signed_code_role"></a> [create\_github\_actions\_signed\_code\_role](#input\_create\_github\_actions\_signed\_code\_role) | Controls whether to grant s3 access and signer access to GitHub Actions | `bool` | `false` | no |
 | <a name="input_create_lambda_cloudwatch_log_group"></a> [create\_lambda\_cloudwatch\_log\_group](#input\_create\_lambda\_cloudwatch\_log\_group) | Controls whether the Lambda Role | `bool` | `true` | no |
 | <a name="input_create_lambda_function_url"></a> [create\_lambda\_function\_url](#input\_create\_lambda\_function\_url) | Controls whether the Lambda Function URL resource should be created | `bool` | `false` | no |
 | <a name="input_create_lambda_role"></a> [create\_lambda\_role](#input\_create\_lambda\_role) | Controls whether the Lambda Role | `bool` | `true` | no |
@@ -88,6 +92,8 @@
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1. | `number` | `-1` | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of IAM role to use for Lambda Function. | `string` | `null` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Lambda Function runtime | `string` | `"nodejs18.x"` | no |
+| <a name="input_signer_profile_name"></a> [signer\_profile\_name](#input\_signer\_profile\_name) | Name of the signer profile to use for signing job | `string` | `null` | no |
+| <a name="input_signing_bucket_name"></a> [signing\_bucket\_name](#input\_signing\_bucket\_name) | Name of the S3 bucket to store code for signing job | `string` | `null` | no |
 | <a name="input_snap_start"></a> [snap\_start](#input\_snap\_start) | (Optional) Snap start settings for low-latency startups | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The absolute path to a local file or directory containing your Lambda source code | `string` | `null` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time your Lambda Function has to run in seconds. | `number` | `3` | no |
@@ -112,3 +118,4 @@
 | <a name="output_lambda_role_name"></a> [lambda\_role\_name](#output\_lambda\_role\_name) | The name of the IAM role created for the Lambda Function |
 | <a name="output_lambda_role_unique_id"></a> [lambda\_role\_unique\_id](#output\_lambda\_role\_unique\_id) | The unique id of the IAM role created for the Lambda Function |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | The qualified arn of the lambda function to be associated with Cloudfront as a Lambda@Edge function |
+<!-- END_TF_DOCS -->

--- a/data.tf
+++ b/data.tf
@@ -73,13 +73,27 @@ data "aws_iam_policy_document" "sign_code" {
 
     actions = [
       "s3:PutObject",
+      "s3:PutObjectTagging",
       "s3:PutObjectAcl",
       "s3:DeleteObject",
       "s3:GetObject",
+      "s3:GetObjectTagging",
     ]
 
     resources = [
       "arn:aws:s3:::${var.signing_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid = "ListBucket"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.signing_bucket_name}",
     ]
   }
 
@@ -89,6 +103,7 @@ data "aws_iam_policy_document" "sign_code" {
     actions = [
       "signer:StartSigningJob",
       "signer:DescribeSigningJob",
+      "signer:ListSigningJobs",
       "signer:GetSigningProfile",
     ]
 

--- a/data.tf
+++ b/data.tf
@@ -68,6 +68,7 @@ data "aws_iam_policy_document" "update_lambda_edge" {
 }
 
 data "aws_iam_policy_document" "sign_code" {
+  #checkov:skip=CKV_AWS_356:Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
   statement {
     sid = "UploadToS3"
 
@@ -100,16 +101,28 @@ data "aws_iam_policy_document" "sign_code" {
   }
 
   statement {
-    sid = "ListDescribeSigningJob"
+    sid = "ListSignerSigningProfileJobs"
 
+    # These action only support all the resources wildcard "*"
     actions = [
-      "signer:DescribeSigningJob",
       "signer:ListSigningJobs",
       "signer:ListSigningProfiles",
     ]
 
     resources = [
       "*",
+    ]
+  }
+
+  statement {
+    sid = "DescribeSigningJob"
+
+    actions = [
+      "signer:DescribeSigningJob",
+    ]
+
+    resources = [
+      "arn:aws:signer:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/signing-jobs/*",
     ]
   }
 

--- a/data.tf
+++ b/data.tf
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "sign_code" {
     ]
 
     resources = [
-      "arn:aws:signer:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:profile/${var.signer_profile_name}",
+      "arn:aws:signer:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:/signing-profiles/${var.signing_profile_name}",
     ]
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -66,3 +66,34 @@ data "aws_iam_policy_document" "update_lambda_edge" {
     }
   }
 }
+
+data "aws_iam_policy_document" "sign_code" {
+  statement {
+    sid = "UploadToS3"
+
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:DeleteObject",
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.signing_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid = "SignCode"
+
+    actions = [
+      "signer:StartSigningJob",
+      "signer:DescribeSigningJob",
+      "signer:GetSigningProfile",
+    ]
+
+    resources = [
+      "arn:aws:signer:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:profile/${var.signer_profile_name}",
+    ]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -72,12 +72,13 @@ data "aws_iam_policy_document" "sign_code" {
     sid = "UploadToS3"
 
     actions = [
-      "s3:PutObject",
       "s3:PutObjectTagging",
       "s3:PutObjectAcl",
-      "s3:DeleteObject",
-      "s3:GetObject",
+      "s3:PutObject",
+      "s3:GetObjectVersion",
       "s3:GetObjectTagging",
+      "s3:GetObject",
+      "s3:DeleteObject",
     ]
 
     resources = [
@@ -90,6 +91,7 @@ data "aws_iam_policy_document" "sign_code" {
 
     actions = [
       "s3:ListBucket",
+      "s3:ListBucketVersions",
     ]
 
     resources = [
@@ -98,12 +100,24 @@ data "aws_iam_policy_document" "sign_code" {
   }
 
   statement {
+    sid = "ListDescribeSigningJob"
+
+    actions = [
+      "signer:DescribeSigningJob",
+      "signer:ListSigningJobs",
+      "signer:ListSigningProfiles",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
     sid = "SignCode"
 
     actions = [
       "signer:StartSigningJob",
-      "signer:DescribeSigningJob",
-      "signer:ListSigningJobs",
       "signer:GetSigningProfile",
     ]
 

--- a/github_action.tf
+++ b/github_action.tf
@@ -47,3 +47,11 @@ resource "aws_iam_role_policy" "update_lambda_edge" {
   role        = module.lambda_gha[0].role.name
   policy      = data.aws_iam_policy_document.update_lambda_edge.json
 }
+
+resource "aws_iam_role_policy" "sign_code" {
+  count = var.create_github_actions_signed_code_role ? 1 : 0
+
+  name_prefix = "SignCode"
+  role        = module.lambda_gha[0].role.name
+  policy      = data.aws_iam_policy_document.sign_code.json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -354,8 +354,8 @@ variable "signing_bucket_name" {
   default     = null
 }
 
-variable "signer_profile_name" {
-  description = "Name of the signer profile to use for signing job"
+variable "signing_profile_name" {
+  description = "Name of the signer signing profile to use for signing job"
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,13 @@ variable "create_lambda_function_url" {
 }
 
 variable "create_github_actions_edge_role" {
-  description = "controls whether to create for lambda edge functions"
+  description = "Controls whether to create for lambda edge functions"
+  type        = bool
+  default     = false
+}
+
+variable "create_github_actions_signed_code_role" {
+  description = "Controls whether to grant s3 access and signer access to GitHub Actions"
   type        = bool
   default     = false
 }
@@ -340,6 +346,18 @@ variable "number_of_managed_policies" {
   description = "Number of AWS managed policies to attach to IAM role for Lambda Function"
   type        = number
   default     = 0
+}
+
+variable "signing_bucket_name" {
+  description = "Name of the S3 bucket to store code for signing job"
+  type        = string
+  default     = null
+}
+
+variable "signer_profile_name" {
+  description = "Name of the signer profile to use for signing job"
+  type        = string
+  default     = null
 }
 
 ##################


### PR DESCRIPTION
GitHub Actions OIDC role requires additional permission for code signing with AWS Signer.

This grants additional permission for GitHub actions to push the lambda code to S3 bucket and trigger signing job.