### PR TITLE
Fix #19 interpolation error

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -69,6 +69,8 @@ data "aws_iam_policy_document" "update_lambda_edge" {
 
 data "aws_iam_policy_document" "sign_code" {
   #checkov:skip=CKV_AWS_356:Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
+  count = var.create_github_actions_signed_code_role ? 1 : 0
+
   statement {
     sid = "UploadToS3"
 

--- a/github_action.tf
+++ b/github_action.tf
@@ -53,5 +53,5 @@ resource "aws_iam_role_policy" "sign_code" {
 
   name_prefix = "SignCode"
   role        = module.lambda_gha[0].role.name
-  policy      = data.aws_iam_policy_document.sign_code.json
+  policy      = data.aws_iam_policy_document.sign_code[0].json
 }


### PR DESCRIPTION
Fixes https://github.com/SPHTech-Platform/terraform-aws-lambda-github-actions/pull/19/files

Terraform tries to run the data resource for aws_iam_policy_document.sign_code when var.create_github_actions_signed_code_role is false. This results in existing module failing with the following error:

![Screenshot 2023-11-29 at 3 26 54 PM](https://github.com/SPHTech-Platform/terraform-aws-lambda-github-actions/assets/12455437/a4204b2d-e444-41d2-8785-180c9c0db203)
