### PR TITLE
Update data.tf

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "update_lambda" {
       "lambda:PublishLayerVersion",
       "lambda:PutProvisionedConcurrencyConfig",
       "lambda:DeleteProvisionedConcurrencyConfig",
+      "lambda:ListProvisionedConcurrencyConfigs",
     ]
     resources = ["arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_prefix}*"]
   }


### PR DESCRIPTION
Added `lambda:ListProvisionedConcurrencyConfigs` permission to list all Lambda versions with provisioned concurrency
To enable using the CLI to list all versions with provisioned concurrency and subsequently delete older version's provisioned concurrency for housekeeping.