### PR TITLE
Allow custom tags to be added to a specific lambda function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,4 +82,6 @@ module "lambda" {
   logging_system_log_level      = var.logging_system_log_level
 
   event_source_mapping = var.event_source_mapping
+  tags                 = var.tags
+  function_tags        = var.function_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -445,3 +445,15 @@ variable "cf_distribution_id" {
   type        = string
   default     = null
 }
+
+variable "tags" {
+  description = "A map of tags to assign to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "function_tags" {
+  description = "A map of tags to assign only to the lambda function"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Example usage: https://github.com/SPHTech/newshub-mobile-backend-infra/pull/956

Just so that we can add custom tags to be added to a specific function, to then be able to be manually triggered based on tag. So that we dont have to append the default_tags for this case