### PR TITLE
decouple addPermissions

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -23,7 +23,6 @@ data "aws_iam_policy_document" "update_lambda" {
     sid = "LambdaUpdateEvent"
 
     actions = [
-      "lambda:AddPermission",
       "lambda:UpdateFunctionCode",
       "lambda:UpdateFunctionConfiguration",
       "lambda:UpdateAlias",
@@ -44,6 +43,17 @@ data "aws_iam_policy_document" "update_lambda" {
         "apigateway:PUT",
       ]
       resources = ["arn:aws:apigateway:${data.aws_region.current.name}::/restapis/${var.apigw_id}/*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_version_identifier ? [1] : []
+    content {
+      sid = "AllowLambdaAddPermissions"
+      actions = [
+        "lambda:AddPermission",
+      ]
+      resources = ["arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.function_prefix}*"]
     }
   }
 }


### PR DESCRIPTION
- decouple `lambda:addPermissions` from the main policy and add only when require