### PR TITLE
**FINAL REMINDER****IMPORTANT** **ACTION REQUIRED** Migration of ubuntu-latest label to platform-eng-ent-v2-dual

### DIFF
--- a/examples/lambda-with-apigateway/.github/workflows/deploy.yml
+++ b/examples/lambda-with-apigateway/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: platform-eng-ent-v2-dual
     strategy:
       matrix:
         go-version: [1.18.x]


### PR DESCRIPTION
**Automated PR**: This PR updates ubuntu-latest runner labels to platform-eng-ent-v2-dual. Migration Deadline is 3rd April 2025