### PR TITLE
added new flag for permission to update Lambda event source mapping

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "update_lambda" {
   }
 
   dynamic "statement" {
-    for_each = var.enable_version_identifier ? [1] : []
+    for_each = var.enable_lambda_update_evt_src_mapping ? [1] : []
     content {
       sid = "AllowLambdaUpdateEvtSrcMapping"
       actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -470,3 +470,10 @@ variable "apigw_id" {
   type        = string
   default     = null
 }
+
+# to allow deployments with other lambda triggers and update version whenever there is new deployment
+variable "enable_lambda_update_evt_src_mapping" {
+  description = "Enable Lambda function to update it's event source mapping when there is a new deployment"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Add `enable_lambda_update_evt_src_mapping` variable to allow Github OIDC to update Lambda's event source mapping